### PR TITLE
Expose StorageConfiguration, RegionPrices, and LinuxPricing publicly so that these structures can be used by unit tests in autospotting.

### DIFF
--- a/ec2_instance_data.go
+++ b/ec2_instance_data.go
@@ -22,9 +22,9 @@ type jsonInstance struct {
 	EBSThroughput      float32                 `json:"ebs_throughput"`
 	PrettyName         string                  `json:"pretty_name"`
 	GPU                int                     `json:"GPU"`
-	Pricing            map[string]regionPrices `json:"pricing"`
+	Pricing            map[string]RegionPrices `json:"pricing"`
 
-	Storage *storageConfiguration `json:"storage"`
+	Storage *StorageConfiguration `json:"storage"`
 
 	VPC struct {
 		//    IPsPerENI int `json:"ips_per_eni"`
@@ -47,14 +47,14 @@ type jsonInstance struct {
 	EBSMaxBandwidth float32 `json:"ebs_max_bandwidth"`
 }
 
-type storageConfiguration struct {
+type StorageConfiguration struct {
 	SSD     bool    `json:"ssd"`
 	Devices int     `json:"devices"`
 	Size    float32 `json:"size"`
 }
 
-type regionPrices struct {
-	Linux        linuxPricing `json:"linux"`
+type RegionPrices struct {
+	Linux        LinuxPricing `json:"linux"`
 	EBSSurcharge float64      `json:"ebs,string"`
 	// ignored for now
 	// Mswinsqlweb interface{}  `json:"mswinSQLWeb"`
@@ -62,7 +62,7 @@ type regionPrices struct {
 	// Mswin       interface{}  `json:"mswin"`
 }
 
-type linuxPricing struct {
+type LinuxPricing struct {
 	OnDemand float64 `json:"ondemand,string"`
 	// ignored for now
 	// Reserved interface{} `json:"reserved"`

--- a/ec2_instance_data_test.go
+++ b/ec2_instance_data_test.go
@@ -16,7 +16,7 @@ func TestData(t *testing.T) {
 				Pricing: map[string]regionPrices{
 					"us-east-1": {
 						Linux: linuxPricing{
-							OnDemand: 0.0059,
+							OnDemand: 0.0058,
 						},
 						EBSSurcharge: 0.0,
 					},

--- a/ec2_instance_data_test.go
+++ b/ec2_instance_data_test.go
@@ -13,9 +13,9 @@ func TestData(t *testing.T) {
 			instance: jsonInstance{
 				InstanceType: "t2.nano",
 				Memory:       0.5,
-				Pricing: map[string]regionPrices{
+				Pricing: map[string]RegionPrices{
 					"us-east-1": {
-						Linux: linuxPricing{
+						Linux: LinuxPricing{
 							OnDemand: 0.0058,
 						},
 						EBSSurcharge: 0.0,
@@ -29,9 +29,9 @@ func TestData(t *testing.T) {
 			instance: jsonInstance{
 				InstanceType: "m3.2xlarge",
 				Memory:       30.0,
-				Pricing: map[string]regionPrices{
+				Pricing: map[string]RegionPrices{
 					"us-east-1": {
-						Linux: linuxPricing{
+						Linux: LinuxPricing{
 							OnDemand: 0.532,
 						},
 						EBSSurcharge: 0.050,
@@ -46,9 +46,9 @@ func TestData(t *testing.T) {
 				InstanceType: "p2.16xlarge",
 				Memory:       732.0,
 				GPU:          16,
-				Pricing: map[string]regionPrices{
+				Pricing: map[string]RegionPrices{
 					"us-east-1": {
-						Linux: linuxPricing{
+						Linux: LinuxPricing{
 							OnDemand: 14.4,
 						},
 						EBSSurcharge: 0,


### PR DESCRIPTION
The RegionPrices and LinuxPricing structures are needed to avoid duplicating these structures inside autospotting for unit testing this pull request: https://github.com/cristim/autospotting/pull/163. This pull request also corrects an issue with the t2.nano unit test failing.