### PR TITLE
Update the instance types with the new ARM instances (t4g, etc)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ check_deps:                                 ## Verify the system has all depende
 
 data/instances.json:
 	@mkdir -p data
-	@wget --quiet -nv $(INSTANCES_URL) -O data/instances.json
+	@wget --quiet -nv $(INSTANCES_URL) -O - | jq 'map(. | del(.pricing["cn-north-1"]) | del(.pricing["cn-northwest-1"]))' > data/instances.json
 
 generate-bindata: check_deps data/instances.json ## Convert instance data into go file
 	@type go-bindata || go get -u github.com/go-bindata/go-bindata/...


### PR DESCRIPTION
This also filters + removes the `cn-north-1` & `cn-northwest-1` regions out of the results. These regions seemed to contain incomplete data which then resulted in parser failures.

Sample:

```json
"cn-north-1": {
  "linux": {
    "ondemand": 0.0,
    "reserved": {
      "yrTerm1Standard.allUpfront": "0",
      "yrTerm1Standard.noUpfront": "0",
      "yrTerm1Standard.partialUpfront": "0",
      "yrTerm3Convertible.allUpfront": "0",
      "yrTerm3Convertible.noUpfront": "0",
      "yrTerm3Convertible.partialUpfront": "0"
    }
  },
  ....
}
```