### PR TITLE
pricing: add other systems' pricing

### DIFF
--- a/ec2_instance_data.go
+++ b/ec2_instance_data.go
@@ -60,15 +60,20 @@ type StorageConfiguration struct {
 }
 
 type RegionPrices struct {
-	Linux        LinuxPricing `json:"linux"`
-	EBSSurcharge float64      `json:"ebs,string"`
-	// ignored for now
-	// Mswinsqlweb interface{}  `json:"mswinSQLWeb"`
-	// Mswinsql    interface{}  `json:"mswinSQL"`
-	// Mswin       interface{}  `json:"mswin"`
+	Linux        				Pricing `json:"linux"`
+	LinuxSQL        		Pricing `json:"linuxSQL"`
+	LinuxSQLEnterprise  Pricing `json:"linuxSQLEnterprise"`
+	LinuxSQLWeb        	Pricing `json:"linuxSQLWeb"`
+	MSWin        				Pricing `json:"mswin"`
+	MSWinSQL        		Pricing `json:"mswinSQL"`
+	MSWinSQLEnterprise  Pricing `json:"mswinSQLEnterprise"`
+	MSWinSQLWeb        	Pricing `json:"mswinSQLWeb"`
+	RHEL        				Pricing `json:"rhel"`
+	SLES        				Pricing `json:"sles"`
+	EBSSurcharge 				float64 `json:"ebs,string"`
 }
 
-type LinuxPricing struct {
+type Pricing struct {
 	OnDemand float64 `json:"ondemand,string"`
 	// ignored for now
 	// Reserved interface{} `json:"reserved"`

--- a/ec2_instance_data.go
+++ b/ec2_instance_data.go
@@ -60,17 +60,17 @@ type StorageConfiguration struct {
 }
 
 type RegionPrices struct {
-	Linux        				Pricing `json:"linux"`
-	LinuxSQL        		Pricing `json:"linuxSQL"`
-	LinuxSQLEnterprise  Pricing `json:"linuxSQLEnterprise"`
-	LinuxSQLWeb        	Pricing `json:"linuxSQLWeb"`
-	MSWin        				Pricing `json:"mswin"`
-	MSWinSQL        		Pricing `json:"mswinSQL"`
-	MSWinSQLEnterprise  Pricing `json:"mswinSQLEnterprise"`
-	MSWinSQLWeb        	Pricing `json:"mswinSQLWeb"`
-	RHEL        				Pricing `json:"rhel"`
-	SLES        				Pricing `json:"sles"`
-	EBSSurcharge 				float64 `json:"ebs,string"`
+	Linux              Pricing `json:"linux"`
+	LinuxSQL           Pricing `json:"linuxSQL"`
+	LinuxSQLEnterprise Pricing `json:"linuxSQLEnterprise"`
+	LinuxSQLWeb        Pricing `json:"linuxSQLWeb"`
+	MSWin              Pricing `json:"mswin"`
+	MSWinSQL           Pricing `json:"mswinSQL"`
+	MSWinSQLEnterprise Pricing `json:"mswinSQLEnterprise"`
+	MSWinSQLWeb        Pricing `json:"mswinSQLWeb"`
+	RHEL               Pricing `json:"rhel"`
+	SLES               Pricing `json:"sles"`
+	EBSSurcharge       float64 `json:"ebs,string"`
 }
 
 type Pricing struct {

--- a/ec2_instance_data_test.go
+++ b/ec2_instance_data_test.go
@@ -16,8 +16,11 @@ func TestData(t *testing.T) {
 				VCPU:         1,
 				Pricing: map[string]RegionPrices{
 					"us-east-1": {
-						Linux: LinuxPricing{
+						Linux: Pricing{
 							OnDemand: 0.0058,
+						},
+						MSWin: Pricing{
+							OnDemand: 0.0081,
 						},
 						EBSSurcharge: 0.0,
 					},
@@ -33,10 +36,13 @@ func TestData(t *testing.T) {
 				VCPU:         8,
 				Pricing: map[string]RegionPrices{
 					"us-east-1": {
-						Linux: LinuxPricing{
+						Linux: Pricing{
 							OnDemand: 0.532,
 						},
-						EBSSurcharge: 0.050,
+						MSWin: Pricing{
+							OnDemand: 1.036,
+						},
+						EBSSurcharge: 0.0,
 					},
 				},
 			},
@@ -51,8 +57,11 @@ func TestData(t *testing.T) {
 				GPU:          16,
 				Pricing: map[string]RegionPrices{
 					"us-east-1": {
-						Linux: LinuxPricing{
+						Linux: Pricing{
 							OnDemand: 14.4,
+						},
+						MSWin: Pricing{
+							OnDemand: 17.344,
 						},
 						EBSSurcharge: 0,
 					},
@@ -88,6 +97,13 @@ func TestData(t *testing.T) {
 						tt.instance.InstanceType,
 						tt.instance.Pricing["us-east-1"].Linux.OnDemand,
 						i.Pricing["us-east-1"].Linux.OnDemand)
+				}
+
+				if i.Pricing["us-east-1"].MSWin.OnDemand != tt.instance.Pricing["us-east-1"].MSWin.OnDemand {
+					t.Errorf("Data(): %v, want MSWin price %v, got %v",
+						tt.instance.InstanceType,
+						tt.instance.Pricing["us-east-1"].MSWin.OnDemand,
+						i.Pricing["us-east-1"].MSWin.OnDemand)
 				}
 
 				if i.Pricing["us-east-1"].EBSSurcharge != tt.instance.Pricing["us-east-1"].EBSSurcharge {


### PR DESCRIPTION
Per README
> Some data fields that were not needed in AutoSpotting may not yet be exposed but they can be added upon demand.

I hope than that this can be merged.

I've added mapping to pricings of systems other than base Linux.
I've also update data and test to current values.