### PR TITLE
fix #20: replace JSON URL with S3 public URL and re-generate data file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BINDATA_FILE := data/generated_bindata.go
 
 # upstream data
-INSTANCES_URL := "https://ec2instances.info/instances.json"
+INSTANCES_URL := "https://s3.amazonaws.com/www.ec2instances.info/instances.json"
 
 DEPS := "wget git jq"
 


### PR DESCRIPTION
The https://ec2instances.info/instances.json URL redirects to the JSON stored in the GitHub repository, which is not updated for some time.
I've updated the JSON URL to the S3 public bucket, where https://ec2instances.info/ is hosted