### PR TITLE
added vpc data to instance data

### DIFF
--- a/ec2_instance_data.go
+++ b/ec2_instance_data.go
@@ -35,8 +35,8 @@ type jsonInstance struct {
 	Storage *StorageConfiguration `json:"storage"`
 
 	VPC struct {
-		//    IPsPerENI int `json:"ips_per_eni"`
-		//    MaxENIs   int `json:"max_enis"`
+		IPsPerENI int `json:"ips_per_eni"`
+		MaxENIs   int `json:"max_enis"`
 	} `json:"vpc"`
 
 	Arch                     []string `json:"arch"`


### PR DESCRIPTION
Hi @cristim 
I've created the PR 
This data is required for comparison with the limitation of network capacity will not be less than the source instance.
This is important for K8s pod capacity.